### PR TITLE
chore: Update API URLs to new IP address

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - .env
     healthcheck:
       test:
-        ["CMD", "curl", "-f", "http://lamebeats.steamfest.live/actuator/health"]
+        ["CMD", "curl", "-f", "http://35.209.62.223/actuator/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -46,8 +46,8 @@ services:
     ports:
       - "5173:5173"
     environment:
-      - REACT_APP_API_URL=http://lamebeats.steamfest.live/api
-      - PUBLIC_URL=http://lamebeats.steamfest.live
+      - REACT_APP_API_URL=http://35.209.62.223/api
+      - PUBLIC_URL=http://35.209.62.223
     restart: unless-stopped
 
 # Network configuration

--- a/frontend/src/components/player/PlayerBar.jsx
+++ b/frontend/src/components/player/PlayerBar.jsx
@@ -37,7 +37,7 @@ const PlayerBar = () => {
             }
 
             // Try to use current domain's API endpoint
-            const apiUrl = `http://lamebeats.steamfest.live/api/songs/${songId}/preview`;
+            const apiUrl = `http://35.209.62.223/api/songs/${songId}/preview`;
 
             console.log(`Fetching preview from: ${apiUrl}`);
 

--- a/frontend/src/pages/admin/AdminMainPage.jsx
+++ b/frontend/src/pages/admin/AdminMainPage.jsx
@@ -14,7 +14,7 @@ export default function AdminMainPage() {
         const fetchSongs = async () => {
             try {
                 setLoading(true);
-                const response = await fetch('http://lamebeats.steamfest.live/api/songs?limit=5', {
+                const response = await fetch('http://35.209.62.223/api/songs?limit=5', {
                     method: 'GET',
                     headers: {
                         'Content-Type': 'application/json',
@@ -39,7 +39,7 @@ export default function AdminMainPage() {
         const fetchAlbums = async () => {
             try {
                 setLoading(true);
-                const response = await fetch('http://lamebeats.steamfest.live/api/albums?limit=5', {
+                const response = await fetch('http://35.209.62.223/api/albums?limit=5', {
                     method: 'GET',
                     headers: {
                         'Content-Type': 'application/json',

--- a/frontend/src/pages/admin/SearchPage.jsx
+++ b/frontend/src/pages/admin/SearchPage.jsx
@@ -38,7 +38,7 @@ export default function SearchPage() {
             if (filters.artist) queryParams.append('artist', 'true');
 
             const response = await fetch(
-                `http://lamebeats.steamfest.live/api/spotify/search?${queryParams.toString()}&page=1&limit=10`,
+                `http://35.209.62.223/api/spotify/search?${queryParams.toString()}&page=1&limit=10`,
                 {
                     method: 'GET',
                     headers: {
@@ -68,7 +68,7 @@ export default function SearchPage() {
 
         try {
             const response = await fetch(
-                `http://lamebeats.steamfest.live/api/spotify/add-track/${trackId}`,
+                `http://35.209.62.223/api/spotify/add-track/${trackId}`,
                 {
                     method: 'POST',
                     headers: {
@@ -136,7 +136,7 @@ export default function SearchPage() {
 
         try {
             const response = await fetch(
-                `http://lamebeats.steamfest.live/api/spotify/add-album/${albumId}`,
+                `http://35.209.62.223/api/spotify/add-album/${albumId}`,
                 {
                     method: 'POST',
                     headers: {

--- a/frontend/src/pages/auth/Login.jsx
+++ b/frontend/src/pages/auth/Login.jsx
@@ -20,7 +20,7 @@ const Login = () => {
     const handleSubmit = async (e) => {
         e.preventDefault();
         try {
-            const response = await fetch('http://lamebeats.steamfest.live/api/users/login', {
+            const response = await fetch('http://35.209.62.223/api/users/login', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(formData),

--- a/frontend/src/pages/auth/Register.jsx
+++ b/frontend/src/pages/auth/Register.jsx
@@ -33,7 +33,7 @@ const Register = () => {
         const avatarUrl = `https://api.dicebear.com/7.x/adventurer/svg?seed=${encodeURIComponent(formData.username)}`;
 
         try {
-            const response = await fetch('http://lamebeats.steamfest.live/api/users/register', {
+            const response = await fetch('http://35.209.62.223/api/users/register', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -15,6 +15,6 @@ export default defineConfig({
         host: true,
         strictPort: true,
         port: 5173,
-        allowedHosts: ['lamebeats.steamfest.live'],
+        allowedHosts: ['35.209.62.223'],
     }
 })


### PR DESCRIPTION
- Update API URLs to the new IP address 35.209.62.223.
- Update frontend Login page to use new IP address.
- Update frontend Register page to use new IP address.
- Update frontend SearchPage to use new IP address.
- Update frontend AdminMainPage to use new IP address.
- Update frontend PlayerBar to use new IP address.
- Update vite config to use new allowed host.
- Update docker-compose to use new IP address.